### PR TITLE
PR: US10.2 - 버그사항 수정 → dev 머지

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -55,11 +55,13 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // 401 에러 처리 - refresh API 요청은 재시도하지 않음
+    // 401 에러 처리 - 인증 관련 API는 재시도하지 않음
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      !originalRequest.url?.includes('/api/users/auth/refresh')
+      !originalRequest.url?.includes('/api/users/auth/refresh') &&
+      !originalRequest.url?.includes('/api/users/auth/login') &&
+      !originalRequest.url?.includes('/api/users/auth/register')
     ) {
       if (isRefreshing) {
         // 이미 갱신 중이면 대기열에 추가

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -6,9 +6,10 @@ import { selectAlerts } from '@/store/slices/alertSlice';
 import { theme } from '@/styles/theme';
 import DrivePortal from '@/components/portal/DrivePortal';
 import DriveOverlayPage from '@/pages/driveOverlay/DriveOverlayPage';
-import { selectIsAuthenticated } from '@/store/slices/authSlice';
+import { selectIsAuthenticated, selectUser, fetchUserProfileAsync } from '@/store/slices/authSlice';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useGetLinkStatusQuery } from '@/store/vehicle/vehicleApi';
+import { useAppDispatch } from '@/hooks/useAppRedux';
 import BottomNav, { NAV_HEIGHT } from './BottomNav';
 
 const Shell = styled.div`
@@ -32,6 +33,7 @@ const isRouteHandle = (h: unknown): h is RouteHandle =>
 
 export default function AppLayout() {
   const [drivingActive, setDrivingActive] = useState(false);
+  const dispatch = useAppDispatch();
 
   const matches = useMatches() as ReadonlyArray<MatchUnknown>;
   const hideBottomNav = matches.some(
@@ -39,6 +41,8 @@ export default function AppLayout() {
   );
 
   const alert = useSelector(selectAlerts);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const user = useSelector(selectUser);
 
   useEffect(() => {
     if (!alert) return;
@@ -52,7 +56,12 @@ export default function AppLayout() {
     }
   }, [alert, drivingActive]);
 
-  const isAuthenticated = useSelector(selectIsAuthenticated);
+  // 앱 시작시 사용자 프로필 불러오기
+  useEffect(() => {
+    if (isAuthenticated && !user) {
+      dispatch(fetchUserProfileAsync());
+    }
+  }, [isAuthenticated, user, dispatch]);
   const { data: linkStatus } = useGetLinkStatusQuery(undefined, {
     skip: !isAuthenticated,
   });

--- a/src/store/vehicle/vehicleApi.ts
+++ b/src/store/vehicle/vehicleApi.ts
@@ -11,7 +11,7 @@ export const vehicleApi = baseApi.injectEndpoints({
 
     //-- 차량 연동 요청  --
     linkVehicle: builder.mutation<LinkStatus, LinkVehicleReq>({
-      query: (data) => ({ url: '/vehicle', method: 'POST', data }),
+      query: (data) => ({ url: '/users/vehicle', method: 'POST', data }),
       async onQueryStarted(_, { dispatch, queryFulfilled }) {
         try {
           const { data: nextStatus } = await queryFulfilled;


### PR DESCRIPTION
# PR: US10.2 - 버그사항 수정 → dev 머지

## 목적

- 버그 사항 수정
---

## 구현/변경 사항

- fix: 차량 등록이 안되는 현상
  - API 엔드포인트 수정: 차량 연동 API 경로를 /vehicle에서 /users/vehicle로 변경

- fix: 마이페이지 사용자 이름 매칭 불일치 현상 
  - 사용자 프로필 자동 로딩: 앱 시작시  인증된 사용자의 프로필 정보 자동 조회
  - Auth 상태 관리: 사용자 프로필 조회  비동기 액션 및 상태 처리 로직 추가

- fix: 로그인시 잘못된 토스트 알림메세지 
  - API 인터셉터: 로그인/회원가입 요청 시  토큰 갱신 방지 로직 추가
  - Refresh token이 없습니다 메세지 -> 적절한 로그인 실패 메세지 표시
  - 로그인 실패 상황에서 401에러를 감지하여 자동으로 토큰 갱신 시도 -> 리프레시가 당연히 없기 때문에 리프레시 실패 메세지 표시되었음
